### PR TITLE
Overload per caricamento da Stream

### DIFF
--- a/FatturaElettronica.Extensions/FatturaElettronicaXmlExtensions.cs
+++ b/FatturaElettronica.Extensions/FatturaElettronicaXmlExtensions.cs
@@ -16,6 +16,16 @@ namespace FatturaElettronica.Extensions
                 fattura.ReadXml(r);
             }
         }
+        
+        public static void ReadXml(this Fattura fattura, Stream stream)
+		{
+			stream.Position = 0;
+			using (var r = XmlReader.Create(stream, new XmlReaderSettings { IgnoreWhitespace = true, IgnoreComments = true }))
+			{
+				fattura.ReadXml(r);
+			}
+		}
+        
         public static void WriteXml(this Fattura fattura, string filePath)
         {
             using (var w = XmlWriter.Create(filePath, new XmlWriterSettings { Indent = true }))


### PR DESCRIPTION
Utilizzati per gestire direttamente uno stream in entrata (es: applicazione esterna che alimenta una directory o form da una pagina web) e importarli senza necessità di passare per un file temporaneo.